### PR TITLE
Remove typography.js theme

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -32,12 +32,6 @@ module.exports = {
       options: {
         modulePath: `${__dirname}/src/cms/cms.js`,
       },
-    },
-    {
-      resolve: `gatsby-plugin-typography`,
-      options: {
-        pathToConfigModule: `src/utils/typography.js`,
-      },
-    },
+    }
   ],
 }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "gatsby-transformer-sharp": "^1.6.21",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
-    "react-helmet": "^5.2.0",
-    "typography": "^0.16.6",
-    "typography-theme-de-young": "^0.16.9"
+    "react-helmet": "^5.2.0"
   },
   "keywords": [
     "gatsby"

--- a/src/utils/typography.js
+++ b/src/utils/typography.js
@@ -1,6 +1,0 @@
-import Typography from "typography";
-import deYoungTheme from "typography-theme-de-young"
-
-const typography = new Typography(deYoungTheme);
-
-export default typography;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2067,7 +2067,7 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
 
-compass-vertical-rhythm@^1.2.1, compass-vertical-rhythm@^1.3.0:
+compass-vertical-rhythm@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/compass-vertical-rhythm/-/compass-vertical-rhythm-1.4.0.tgz#41cff92ef369d27e295d685f1ff420ff410e9883"
   dependencies:
@@ -10406,23 +10406,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typography-breakpoint-constants@^0.15.10:
-  version "0.15.10"
-  resolved "https://registry.yarnpkg.com/typography-breakpoint-constants/-/typography-breakpoint-constants-0.15.10.tgz#bd5308dd57250e7f28a8c6e1c0e668ddf1178c5c"
-
 typography-normalize@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/typography-normalize/-/typography-normalize-0.14.0.tgz#1d77c1fe2aaf4a51b3673c4c85c85a65a2d4b573"
 
-typography-theme-de-young@^0.16.9:
-  version "0.16.9"
-  resolved "https://registry.yarnpkg.com/typography-theme-de-young/-/typography-theme-de-young-0.16.9.tgz#3c7ce11c87c1190a34330e7454cae320b4bd4ff7"
-  dependencies:
-    compass-vertical-rhythm "^1.2.1"
-    gray-percentage "^2.0.0"
-    typography-breakpoint-constants "^0.15.10"
-
-typography@^0.16.0, typography@^0.16.6:
+typography@^0.16.0:
   version "0.16.6"
   resolved "https://registry.yarnpkg.com/typography/-/typography-0.16.6.tgz#8eeb6a3f10a97fd08025132bb50272104ae72aa3"
   dependencies:


### PR DESCRIPTION
Addition of entire bulma moudule overrides typography themes. Removing for now